### PR TITLE
Fix zero indent bug

### DIFF
--- a/autoload/localindent.vim
+++ b/autoload/localindent.vim
@@ -139,6 +139,10 @@ function! s:update(force) abort
       else
         let cur_line = n
       endif
+
+      if indent(cur_line) == 0
+        return s:clear()
+      endif
     else
       return s:clear()
     endif


### PR DESCRIPTION
On empty lines surrounded with zero the behavior for showing the indents is kind of unpredictable. See image.

![Screenshot 2019-06-12 at 17 17 38](https://user-images.githubusercontent.com/7188844/59363800-131e1600-8d36-11e9-9a5d-d31872576e0d.png)

This should fix this.
